### PR TITLE
GH-71: Drop 'patientNumber' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please refer to the following wiki pages for explanations for configuring those 
 The application can be started for development tests with the following Gradle task:
 
 ```
-./gradlew clean bootRun -Dspring.profiles.active=qa
+./gradlew bootRun -Dspring.profiles.active=qa
 ```
 
 Then it is accessible in the browser under the URL http://localhost:8080 (login: user / pwd).

--- a/infrastructure/configuration/src/main/java/ksch/TestDataInitializer.java
+++ b/infrastructure/configuration/src/main/java/ksch/TestDataInitializer.java
@@ -64,11 +64,6 @@ class TestPatient implements Patient {
     }
 
     @Override
-    public String getPatientNumber() {
-        return null;
-    }
-
-    @Override
     public String getName() {
         return "Jayadev Mitali";
     }

--- a/patient-management/patient-management-api/src/main/java/ksch/patientmanagement/patient/Patient.java
+++ b/patient-management/patient-management-api/src/main/java/ksch/patientmanagement/patient/Patient.java
@@ -26,8 +26,6 @@ public interface Patient {
 
     UUID getId();
 
-    String getPatientNumber();
-
     String getName();
 
     String getNameFather();

--- a/patient-management/patient-management-api/src/main/java/ksch/patientmanagement/patient/PatientQueries.java
+++ b/patient-management/patient-management-api/src/main/java/ksch/patientmanagement/patient/PatientQueries.java
@@ -16,18 +16,9 @@
 
 package ksch.patientmanagement.patient;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface PatientQueries {
-
-    /**
-     * Searches for patients in the database by their name or patient number.
-     */
-    List<Patient> findByNameOrNumber(String nameOrNumber);
-
-    Optional<Patient> findByPatientNumber(String patientNumber);
 
     /**
      * Provides access on the details of a patient with the given technical identifier.

--- a/patient-management/patient-management-api/src/test/java/ksch/patientmanagement/TestPatientEntity.java
+++ b/patient-management/patient-management-api/src/test/java/ksch/patientmanagement/TestPatientEntity.java
@@ -30,8 +30,6 @@ public class TestPatientEntity implements Patient {
 
     private UUID id = UUID.randomUUID();
 
-    private String patientNumber = "0815";
-
     private String name = "Jane Doe";
 
     private String nameFather = "John Doe";

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/NumericValue.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/NumericValue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ksch.patientmanagement.patient;
+package ksch.patientmanagement.opdnumber;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,21 +28,24 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.TableGenerator;
 
+/**
+ * Utility class for generation of the numeric part of new OPD numbers.
+ */
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
-@TableGenerator(name = "patient_index_number", initialValue = 999)
-class PatientNumberIndex {
+@TableGenerator(name = "numeric_part_of_opd_number", initialValue = 999)
+class NumericValue {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.TABLE, generator = "patient_index_number")
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "numeric_part_of_opd_number")
     @Column(unique = true)
-    private int index;
+    private int value;
 
     @Override
     public String toString() {
-        return String.valueOf(index);
+        return String.valueOf(value);
     }
 }

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/OpdNumberGenerator.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/OpdNumberGenerator.java
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package ksch;
+package ksch.patientmanagement.opdnumber;
 
-import ksch.wicket.PageComponentTest;
-import org.junit.Test;
+public interface OpdNumberGenerator {
 
-public class IndexTest extends PageComponentTest {
-
-    @Test
-    public void should_render_index_page() {
-        tester.startPage(Index.class);
-        tester.assertRenderedPage(Index.class);
-    }
+    /**
+     * Generates a new OPD number as identifier for the hospital visit.
+     */
+    String generateOpdNumber();
 }

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/OpdNumberGeneratorImpl.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/OpdNumberGeneratorImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ksch.patientmanagement.patient;
+package ksch.patientmanagement.opdnumber;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,15 +23,15 @@ import java.util.Calendar;
 
 @Service
 @RequiredArgsConstructor
-public class PatientNumberGeneratorImpl implements PatientNumberGenerator {
+class OpdNumberGeneratorImpl implements OpdNumberGenerator {
 
     private static final int currentYearWithTwoDigits = Calendar.getInstance().get(Calendar.YEAR) % 100;
 
-    private final PatientNumberIndexRepository patientNumberIndexRepository;
+    private final OpdNumberRepository opdNumberRepository;
 
     @Override
     public synchronized String generateOpdNumber() {
-        PatientNumberIndex patientNumberIndex = patientNumberIndexRepository.save(new PatientNumberIndex());
-        return String.format("%s-%s", currentYearWithTwoDigits, patientNumberIndex);
+        NumericValue numericValue = opdNumberRepository.save(new NumericValue());
+        return String.format("%s-%s", currentYearWithTwoDigits, numericValue);
     }
 }

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/OpdNumberRepository.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/opdnumber/OpdNumberRepository.java
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package ksch.patientmanagement.patient;
+package ksch.patientmanagement.opdnumber;
 
-public interface PatientNumberGenerator {
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
-    String generateOpdNumber();
+@Repository
+interface OpdNumberRepository extends CrudRepository<NumericValue, Integer> {
 }

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientEntity.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientEntity.java
@@ -47,9 +47,6 @@ public class PatientEntity implements Patient {
     @Column(unique = true)
     private UUID id;
 
-    @Column(unique = true)
-    private String patientNumber;
-
     @Column
     private String name;
 
@@ -69,7 +66,6 @@ public class PatientEntity implements Patient {
     public static PatientEntity toPatientEntity(Patient patient) {
         return PatientEntity.builder()
                 .id(patient.getId())
-                .patientNumber(patient.getPatientNumber())
                 .name(patient.getName())
                 .nameFather(patient.getNameFather())
                 .dateOfBirth(patient.getDateOfBirth())

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientQueriesImpl.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientQueriesImpl.java
@@ -19,28 +19,13 @@ package ksch.patientmanagement.patient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PatientQueriesImpl implements PatientQueries {
 
     private final PatientRepository patientRepository;
-
-    @Override
-    public List<Patient> findByNameOrNumber(String nameOrNumber) {
-        return patientRepository.findByPatientNumberOrName(nameOrNumber).stream()
-                .map(p -> (Patient) p)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public Optional<Patient> findByPatientNumber(String patientNumber) {
-        return patientRepository.findByPatientNumber(patientNumber).map(p -> p);
-    }
 
     @Override
     public Patient getById(UUID patientId) {

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientRepository.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientRepository.java
@@ -16,26 +16,15 @@
 
 package ksch.patientmanagement.patient;
 
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 
 import javax.transaction.Transactional;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Transactional
 @Component
 public interface PatientRepository extends CrudRepository<PatientEntity, UUID> {
 
-    @Query("Select p from PatientEntity p where " +
-            "lower(p.name) like lower(concat('%',:patientNumberOrName,'%')) or " +
-            "lower(p.patientNumber) like lower(concat('%',:patientNumberOrName,'%'))" )
-    List<PatientEntity> findByPatientNumberOrName(@Param("patientNumberOrName") String patientNumberOrName);
-
     PatientEntity getById(UUID patientId);
-
-    Optional<PatientEntity> findByPatientNumber(String patientNumber);
 }

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientTransactionsImpl.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/patient/PatientTransactionsImpl.java
@@ -28,16 +28,11 @@ public class PatientTransactionsImpl implements PatientTransactions {
 
     private final PatientRepository patientRepository;
 
-    private final PatientNumberGenerator patientNumberGenerator;
-
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public Patient create(Patient patient) {
         PatientEntity patientEntity = toPatientEntity(patient);
-        if (patient.getPatientNumber() == null) {
-            patientEntity.setPatientNumber(patientNumberGenerator.generateOpdNumber());
-        }
         patientEntity = patientRepository.save(patientEntity);
         eventPublisher.publishEvent(new PatientCreatedEvent(patientEntity));
         return patientEntity;

--- a/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/visit/VisitTransactionsImpl.java
+++ b/patient-management/patient-management-impl/src/main/java/ksch/patientmanagement/visit/VisitTransactionsImpl.java
@@ -16,8 +16,8 @@
 
 package ksch.patientmanagement.visit;
 
+import ksch.patientmanagement.opdnumber.OpdNumberGenerator;
 import ksch.patientmanagement.patient.Patient;
-import ksch.patientmanagement.patient.PatientNumberGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,12 +32,12 @@ public class VisitTransactionsImpl implements VisitTransactions {
 
     private final VisitRepository visitRepository;
 
-    private final PatientNumberGenerator patientNumberGenerator;
+    private final OpdNumberGenerator opdNumberGenerator;
 
     @Override
     public Visit startVisit(Patient patient, VisitType visitType) {
         VisitEntity visit = VisitEntity.builder()
-                .opdNumber(patientNumberGenerator.generateOpdNumber())
+                .opdNumber(opdNumberGenerator.generateOpdNumber())
                 .timeStart(now())
                 .type(visitType)
                 .patient(toPatientEntity(patient))

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/TestPatient.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/TestPatient.java
@@ -30,8 +30,6 @@ public class TestPatient implements Patient {
 
     private UUID id = UUID.randomUUID();
 
-    private String patientNumber = "0815-" + UUID.randomUUID();
-
     private String name = "Jane Doe";
 
     private String nameFather = "John Doe";

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/opdnumber/NumericValueRepositoryTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/opdnumber/NumericValueRepositoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ksch.patientmanagement.patient;
+package ksch.patientmanagement.opdnumber;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,19 +26,19 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
-public class PatientNumberIndexRepositoryTest {
+public class NumericValueRepositoryTest {
 
     @Autowired
-    private PatientNumberIndexRepository repo;
+    private OpdNumberRepository repo;
 
     @Test
     public void should_retrieve_incremented_number_from_database() {
-        PatientNumberIndex no1 = repo.save(new PatientNumberIndex());
-        PatientNumberIndex no2 = repo.save(new PatientNumberIndex());
+        NumericValue no1 = repo.save(new NumericValue());
+        NumericValue no2 = repo.save(new NumericValue());
 
         assertEquals("Patient number index doesn't start with expected initial value.",
-                1000, no1.getIndex());
+                1000, no1.getValue());
         assertEquals("Patient number index didn't get incremented by one for the second value.",
-                1001, no2.getIndex());
+                1001, no2.getValue());
     }
 }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/opdnumber/OpdNumberGeneratorTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/opdnumber/OpdNumberGeneratorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ksch.patientmanagement.patient;
+package ksch.patientmanagement.opdnumber;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,38 +30,38 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PatientNumberGeneratorTest {
+public class OpdNumberGeneratorTest {
 
-    private static final int PATIENT_INDEX_NUMBER = 1011;
+    private static final int NUMERIC_VALUE = 1011;
 
     @InjectMocks
-    private PatientNumberGeneratorImpl patientNumberGenerator;
+    private OpdNumberGeneratorImpl opdNumberGenerator;
 
     @Mock
-    private PatientNumberIndexRepository patientNumberIndexRepository;
+    private OpdNumberRepository opdNumberRepository;
 
     private final int currentYearWithTwoDigits = Calendar.getInstance().get(Calendar.YEAR) % 100;
 
     @Before
     public void setup() {
-        when(patientNumberIndexRepository.save(any(PatientNumberIndex.class)))
-                .thenReturn(new PatientNumberIndex(PATIENT_INDEX_NUMBER));
+        when(opdNumberRepository.save(any(NumericValue.class)))
+                .thenReturn(new NumericValue(NUMERIC_VALUE));
     }
 
     @Test
     public void should_prepend_year() {
-        String generatedPatientNumber = patientNumberGenerator.generateOpdNumber();
+        String generatedOpdNumber = opdNumberGenerator.generateOpdNumber();
 
-        assertTrue("Generated patient number '" + generatedPatientNumber + "' doesn't start with current year",
-                generatedPatientNumber.startsWith(currentYearWithTwoDigits + "-"));
+        assertTrue("Generated OPD number '" + generatedOpdNumber + "' doesn't start with current year",
+                generatedOpdNumber.startsWith(currentYearWithTwoDigits + "-"));
     }
 
     @Test
     public void should_contain_patient_index_number() {
-        String generatedPatientNumber = patientNumberGenerator.generateOpdNumber();
+        String generatedPatientNumber = opdNumberGenerator.generateOpdNumber();
 
         assertTrue("Generated patient number '" + generatedPatientNumber +
-                        "' doesn't contain the patient index number '" + PATIENT_INDEX_NUMBER + "'.",
-                generatedPatientNumber.contains("-" + PATIENT_INDEX_NUMBER));
+                        "' doesn't contain the patient index number '" + NUMERIC_VALUE + "'.",
+                generatedPatientNumber.contains("-" + NUMERIC_VALUE));
     }
 }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientEntityTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientEntityTest.java
@@ -44,11 +44,6 @@ public class PatientEntityTest {
             }
 
             @Override
-            public String getPatientNumber() {
-                return "1234-123";
-            }
-
-            @Override
             public String getName() {
                 return "John C. Doe";
             }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientQueriesTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientQueriesTest.java
@@ -22,15 +22,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 
-import static java.time.LocalDate.now;
-import static ksch.patientmanagement.patient.Gender.MALE;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PatientQueriesTest {
@@ -42,38 +36,11 @@ public class PatientQueriesTest {
     private PatientRepository patientRepository;
 
     @Test
-    public void should_retrieve_patient_by_patient_number() {
-        String patientNumber = "1234";
-        when(patientRepository.findByPatientNumberOrName(patientNumber))
-                .thenReturn(listOf(buildTestPatient(patientNumber)));
-
-        List<Patient> patients = patientQueries.findByNameOrNumber(patientNumber);
-
-        assertTrue("Could not find patient by patient number.", patients.size() > 0);
-        verify(patientRepository).findByPatientNumberOrName(patientNumber);
-    }
-
-    @Test
     public void should_get_patient_by_id() {
         Patient p = PatientEntity.builder().id(UUID.randomUUID()).build();
 
         patientQueries.getById(p.getId());
 
         verify(patientRepository).getById(p.getId());
-    }
-
-    private PatientEntity buildTestPatient(String patientNumber) {
-        return PatientEntity.builder()
-                .id(UUID.randomUUID())
-                .patientNumber(patientNumber)
-                .name("John Doe")
-                .dateOfBirth(now())
-                .gender(MALE)
-                .address("Kirpal Sagar")
-                .build();
-    }
-
-    private List<PatientEntity> listOf(PatientEntity... patient) {
-        return Arrays.asList(patient);
     }
 }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientRepositoryTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientRepositoryTest.java
@@ -23,12 +23,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -48,43 +44,5 @@ public class PatientRepositoryTest {
         Patient createdPatient = patientRepository.save(patient);
 
         assertNotNull(createdPatient.getId());
-    }
-
-    @Test
-    public void should_find_patient_by_name() {
-        createTestPatient("KSA-18-1001", "Jane Doe");
-
-        List<PatientEntity> retrievedPatients = patientRepository.findByPatientNumberOrName("jane");
-
-        assertEquals("Could not find patient in database by searching her name",
-                1, retrievedPatients.size());
-    }
-
-    @Test
-    public void should_find_patient_by_id() {
-        createTestPatient("KSA-19-1002", "Jane Doe");
-
-        List<PatientEntity> retrievedPatients = patientRepository.findByPatientNumberOrName("-19-");
-
-        assertEquals("Could not find patient in database by searching her medical record number",
-                1, retrievedPatients.size());
-    }
-
-    @Test
-    public void should_find_patient_by_patient_number() {
-        createTestPatient("KSA-19-1004", "Jane Doe");
-
-        Optional<PatientEntity> patient = patientRepository.findByPatientNumber("KSA-19-1004");
-
-        assertTrue("Could not find patient by patient number.", patient.isPresent());
-    }
-
-    private void createTestPatient(String patientNumber, String name) {
-        patientRepository.save(PatientEntity.builder()
-                .dateOfBirth(LocalDate.now())
-                .gender(Gender.FEMALE)
-                .name(name)
-                .patientNumber(patientNumber)
-                .build());
     }
 }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientTransactionsTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/patient/PatientTransactionsTest.java
@@ -25,7 +25,6 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,30 +43,15 @@ public class PatientTransactionsTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    @Mock
-    private PatientNumberGenerator patientNumberGenerator;
-
     @Test
     public void should_create_patient() {
-        when(patientNumberGenerator.generateOpdNumber()).thenReturn("18-5322");
         when(patientRepository.save(any(PatientEntity.class))).then(returnsFirstArg());
         PatientEntity p = PatientEntity.builder().id(UUID.randomUUID()).build();
 
         Patient createdPatient = patientService.create(p);
 
         assertNotNull(createdPatient);
-        assertEquals("18-5322", createdPatient.getPatientNumber());
         verify(patientRepository).save(any(PatientEntity.class));
         verify(eventPublisher).publishEvent(any(PatientCreatedEvent.class));
-    }
-
-    @Test
-    public void should_use_existing_patient_number_during_patient_creation() {
-        when(patientRepository.save(any(PatientEntity.class))).then(returnsFirstArg());
-        PatientEntity p = PatientEntity.builder().id(UUID.randomUUID()).patientNumber("KSA-15-97433").build();
-
-        Patient createdPatient = patientService.create(p);
-
-        assertEquals("KSA-15-97433", createdPatient.getPatientNumber());
     }
 }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/visit/VisitQueriesTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/visit/VisitQueriesTest.java
@@ -118,11 +118,6 @@ public class VisitQueriesTest {
             }
 
             @Override
-            public String getPatientNumber() {
-                return "0815-" + UUID.randomUUID();
-            }
-
-            @Override
             public String getName() {
                 return "John";
             }

--- a/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/visit/VisitRepositoryTest.java
+++ b/patient-management/patient-management-impl/src/test/java/ksch/patientmanagement/visit/VisitRepositoryTest.java
@@ -45,7 +45,7 @@ public class VisitRepositoryTest {
 
     @Test
     public void should_store_visit() {
-        PatientEntity patient = createTestPatient("KSA-123", "John Doe");
+        PatientEntity patient = createTestPatient("John Doe");
 
         VisitEntity visit = createNewVisit(patient);
 
@@ -55,8 +55,8 @@ public class VisitRepositoryTest {
 
     @Test
     public void should_find_visits_by_patient_id() {
-        PatientEntity patient = createTestPatient("KSA-124", "John Doe");
-        VisitEntity visit = createNewVisit(patient);
+        PatientEntity patient = createTestPatient("John Doe");
+        createNewVisit(patient);
 
         List<VisitEntity> retrievedVisits = visitRepository.findAllByPatientId(patient.getId());
 
@@ -65,8 +65,8 @@ public class VisitRepositoryTest {
 
     @Test
     public void should_find_all_active_opt_visits() {
-        createNewVisit(createTestPatient("KSA-124", "John Doe"), VisitType.OPD);
-        createNewVisit(createTestPatient("KSA-125", "Jane Doe"), VisitType.IPD);
+        createNewVisit(createTestPatient("John Doe"), VisitType.OPD);
+        createNewVisit(createTestPatient("Jane Doe"), VisitType.IPD);
 
         List<VisitEntity> allActiveOptVisits = visitRepository.findAllActiveOptVisits();
 
@@ -87,12 +87,11 @@ public class VisitRepositoryTest {
         return visitRepository.save(visit);
     }
 
-    private PatientEntity createTestPatient(String patientNumber, String name) {
+    private PatientEntity createTestPatient(String name) {
         return patientRepository.save(PatientEntity.builder()
                 .dateOfBirth(LocalDate.now())
                 .gender(Gender.FEMALE)
                 .name(name)
-                .patientNumber(patientNumber)
                 .build());
     }
 }

--- a/patient-management/patient-management-web/src/main/java/ksch/patientmanagement/GeneralPatientInformation.java
+++ b/patient-management/patient-management-web/src/main/java/ksch/patientmanagement/GeneralPatientInformation.java
@@ -27,9 +27,7 @@ import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.RadioChoice;
-import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
@@ -68,7 +66,6 @@ public class GeneralPatientInformation extends Panel {
         add(dischargeButton);
         add(new StartVisitForm());
         add(new UpdatePatientForm(patient));
-        add(new TextField<>("patientNumber", new Model<>(patient.getPatientNumber())));
     }
 
     private Button createStartVisitButton() {

--- a/patient-management/patient-management-web/src/main/java/ksch/patientmanagement/PatientInfoBar.java
+++ b/patient-management/patient-management-web/src/main/java/ksch/patientmanagement/PatientInfoBar.java
@@ -25,7 +25,6 @@ public class PatientInfoBar extends Panel {
     public PatientInfoBar(Patient patient) {
         super("patientInfoBar");
 
-        add(new Label("patientNumber", patient.getPatientNumber()));
         add(new Label("name", patient.getFullName()));
         add(new Label("age", patient.getAgeInYears()));
     }

--- a/patient-management/patient-management-web/src/main/java/ksch/patientmanagement/PatientResource.java
+++ b/patient-management/patient-management-web/src/main/java/ksch/patientmanagement/PatientResource.java
@@ -37,8 +37,6 @@ public class PatientResource implements Patient, Serializable {
 
     private UUID id;
 
-    private String patientNumber;
-
     private String name;
 
     private String nameFather;
@@ -52,7 +50,6 @@ public class PatientResource implements Patient, Serializable {
     public static PatientResource toPatientResource(Patient patient) {
         return PatientResource.builder()
                 .id(patient.getId())
-                .patientNumber(patient.getPatientNumber())
                 .name(patient.getName())
                 .nameFather(patient.getNameFather())
                 .dateOfBirth(patient.getDateOfBirth())

--- a/patient-management/patient-management-web/src/main/resources/static/ksch/patientmanagement/GeneralPatientInformation.html
+++ b/patient-management/patient-management-web/src/main/resources/static/ksch/patientmanagement/GeneralPatientInformation.html
@@ -48,10 +48,6 @@ limitations under the License.
             </div>
             <div class="card-body">
                 <div class="modal-body">
-                    <div class="form-group">
-                        <label for="patientNumber">Patient number</label>
-                        <input wicket:id="patientNumber" value="[0000]" type="text" class="form-control" id="patientNumber" readonly>
-                    </div>
                     <form wicket:id="updatePatientForm" class="needs-validation" novalidate>
                             <span wicket:id="patientFormFields" >
                                 [patient form fields]

--- a/patient-management/patient-management-web/src/main/resources/static/ksch/patientmanagement/PatientInfoBar.html
+++ b/patient-management/patient-management-web/src/main/resources/static/ksch/patientmanagement/PatientInfoBar.html
@@ -43,7 +43,6 @@ limitations under the License.
     <wicket:panel>
 
         <div class="info-bar bg-light">
-            <span class="info-bar-item">Patient Number: <span wicket:id="patientNumber">[patient number]</span></span>
             <span class="info-bar-item">Name: <span wicket:id="name">[name]</span></span>
             <span class="info-bar-item">Age: <span wicket:id="age">[age]</span></span>
         </div>

--- a/patient-management/patient-management-web/src/test/java/ksch/patientmanagement/PatientResourceTest.java
+++ b/patient-management/patient-management-web/src/test/java/ksch/patientmanagement/PatientResourceTest.java
@@ -46,11 +46,6 @@ public class PatientResourceTest {
             }
 
             @Override
-            public String getPatientNumber() {
-                return "1234-123";
-            }
-
-            @Override
             public String getName() {
                 return "John C. Doe";
             }

--- a/reporting/reporting-impl/src/test/java/ksch/event/EventListenerTest.java
+++ b/reporting/reporting-impl/src/test/java/ksch/event/EventListenerTest.java
@@ -70,11 +70,6 @@ class PatientAdapter implements Patient {
     }
 
     @Override
-    public String getPatientNumber() {
-        return null;
-    }
-
-    @Override
     public String getName() {
         return null;
     }

--- a/user-interface/src/test/java/ksch/NumericValueTest.java
+++ b/user-interface/src/test/java/ksch/NumericValueTest.java
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package ksch.patientmanagement.patient;
+package ksch;
 
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
+import ksch.wicket.PageComponentTest;
+import org.junit.Test;
 
-@Repository
-interface PatientNumberIndexRepository extends CrudRepository<PatientNumberIndex, Integer> {
+public class NumericValueTest extends PageComponentTest {
+
+    @Test
+    public void should_render_index_page() {
+        tester.startPage(Index.class);
+        tester.assertRenderedPage(Index.class);
+    }
 }

--- a/user-interface/src/test/java/ksch/registration/EditPatientDetailsActivityTest.java
+++ b/user-interface/src/test/java/ksch/registration/EditPatientDetailsActivityTest.java
@@ -76,7 +76,6 @@ public class EditPatientDetailsActivityTest extends WebPageTest {
         tester.assertRenderedPage(EditPatientDetails.class);
 
         // General tab
-        tester.assertContains(patient.getPatientNumber());
         tester.assertContains(patient.getName());
 
         // Orders tab

--- a/user-interface/src/test/java/ksch/testdata/TestPatient.java
+++ b/user-interface/src/test/java/ksch/testdata/TestPatient.java
@@ -30,11 +30,6 @@ public class TestPatient implements Patient {
     }
 
     @Override
-    public String getPatientNumber() {
-        return "0815-" + UUID.randomUUID();
-    }
-
-    @Override
     public String getName() {
         return "John Doe";
     }


### PR DESCRIPTION
At the moment, in the KSCH there will always be a new medical
record for every visit of a patient. This is identified by
an OPD number, in various indicies. So the 'patientNumber' concept
also shouldn't be used in this application, for now.